### PR TITLE
Add initial primary brand color variables

### DIFF
--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -39,6 +39,16 @@ $purple-80: #D4BBFF !default;
 $purple-90: #EBDCFF !default;
 $black:    #000 !default;
 
+$primary-10: #260058 !default;
+$primary-20: #3F0F81 !default;
+$primary-30: #572E99 !default;
+$primary-40: #6F48B2 !default;
+$primary-50: #8962CD !default;
+$primary-60: #A37CEA !default;
+$primary-70: #BE99FF !default;
+$primary-80: #D4BBFF !default;
+$primary-90: #EBDCFF !default;
+
 $grays: () !default;
 $grays: map-merge((
   "100": $gray-100,
@@ -79,7 +89,7 @@ $colors: map-merge((
   "gray-dark":  $gray-800
 ), $colors);
 
-$primary:       $purple-40 !default;
+$primary:       $primary-40 !default;
 $secondary:     $coral-40 !default;
 $success:       $green !default;
 $info:          $cyan !default;

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -19,6 +19,15 @@ $gray-600: #6c757d !default;
 $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
+$purple-10: #260058 !default;
+$purple-20: #3F0F81 !default;
+$purple-30: #572E99 !default;
+$purple-40: #6F48B2 !default;
+$purple-50: #8962CD !default;
+$purple-60: #A37CEA !default;
+$purple-70: #BE99FF !default;
+$purple-80: #D4BBFF !default;
+$purple-90: #EBDCFF !default;
 $black:    #000 !default;
 
 $grays: () !default;
@@ -36,7 +45,6 @@ $grays: map-merge((
 
 $blue:    #007bff !default;
 $indigo:  #6610f2 !default;
-$purple:  #6f42c1 !default;
 $pink:    #e83e8c !default;
 $red:     #dc3545 !default;
 $orange:  #fd7e14 !default;
@@ -50,7 +58,6 @@ $colors: () !default;
 $colors: map-merge((
   "blue":       $blue,
   "indigo":     $indigo,
-  "purple":     $purple,
   "pink":       $pink,
   "red":        $red,
   "orange":     $orange,
@@ -63,7 +70,7 @@ $colors: map-merge((
   "gray-dark":  $gray-800
 ), $colors);
 
-$primary:       $teal !default;
+$primary:       $purple-40 !default;
 $secondary:     $gray-600 !default;
 $success:       $green !default;
 $info:          $cyan !default;

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -10,6 +10,15 @@
 
 // stylelint-disable
 $white:    #fff !default;
+$coral-10: #3A0A00 !default;
+$coral-20: #5E1600 !default;
+$coral-30: #852300 !default;
+$coral-40: #AD3306 !default;
+$coral-50: #CF4B20 !default;
+$coral-60: #F16437 !default;
+$coral-70: #FF8B67 !default;
+$coral-80: #FFB59F !default;
+$coral-90: #FFDBD0 !default;
 $gray-100: #f8f9fa !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
@@ -71,7 +80,7 @@ $colors: map-merge((
 ), $colors);
 
 $primary:       $purple-40 !default;
-$secondary:     $gray-600 !default;
+$secondary:     $coral-40 !default;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $yellow !default;

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -10,15 +10,6 @@
 
 // stylelint-disable
 $white:    #fff !default;
-$coral-10: #3A0A00 !default;
-$coral-20: #5E1600 !default;
-$coral-30: #852300 !default;
-$coral-40: #AD3306 !default;
-$coral-50: #CF4B20 !default;
-$coral-60: #F16437 !default;
-$coral-70: #FF8B67 !default;
-$coral-80: #FFB59F !default;
-$coral-90: #FFDBD0 !default;
 $gray-100: #f8f9fa !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
@@ -90,7 +81,7 @@ $colors: map-merge((
 ), $colors);
 
 $primary:       $primary-40 !default;
-$secondary:     $coral-40 !default;
+$secondary:     $gray-600 !default;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $yellow !default;


### PR DESCRIPTION
Added the primary color that is defined in Figma for now:


<img width="626" alt="Screenshot 2024-04-23 at 09 00 42" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/3135ac17-c7a8-4c26-b233-d739bddd9961">

As discussed in Slack, we should vote on the secondary color later on and use accents of the primary color for now.
