### PR TITLE
Decrease basic page h1 and h2 font sizes

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -42,6 +42,7 @@ p, ul, ol {
 
 .page-header h1 {
     margin: 0;
+    font-size: 2.85rem;
 }
 
 .container .section {
@@ -60,6 +61,7 @@ p, ul, ol {
 .content-constrained h2 {
     text-align: left;
     margin-bottom: 1rem;
+    font-size: 2.25rem;
 }
 
 .content-constrained h3 {


### PR DESCRIPTION
## Description
Adjusting basic page h1 and h2 headings to be a bit smaller.

## Change Type
- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
AFTER:
<img width="1493" alt="Screenshot 2024-04-23 at 21 51 22" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/369730ba-ad55-4629-aff3-1bd8139da68e">

BEFORE:
<img width="1497" alt="Screenshot 2024-04-23 at 21 51 56" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/2282117b-9d1b-452e-acb2-96ad66aab351">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->