### PR TITLE
Fix primary variables purple color mapping; make footer a darker purple tone

### DIFF
--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -83,7 +83,7 @@ $colors: map-merge((
   "gray-dark":  $gray-800
 ), $colors);
 
-$primary:       #69548D !default;
+$primary:       $primary-40 !default;
 $secondary:     $gray-600 !default;
 $success:       $green !default;
 $info:          $cyan !default;

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -28,17 +28,20 @@ $purple-60: #A37CEA !default;
 $purple-70: #BE99FF !default;
 $purple-80: #D4BBFF !default;
 $purple-90: #EBDCFF !default;
+$purple-95: #F7EDFF !default;
+$purple-99: #FFFBFF !default;
 $black:    #000 !default;
-
-$primary-10: #260058 !default;
-$primary-20: #3F0F81 !default;
-$primary-30: #572E99 !default;
-$primary-40: #6F48B2 !default;
-$primary-50: #8962CD !default;
-$primary-60: #A37CEA !default;
-$primary-70: #BE99FF !default;
-$primary-80: #D4BBFF !default;
-$primary-90: #EBDCFF !default;
+$primary-10: $purple-10 !default;
+$primary-20: $purple-20 !default;
+$primary-30: $purple-30 !default;
+$primary-40: $purple-40 !default;
+$primary-50: $purple-50 !default;
+$primary-60: $purple-60 !default;
+$primary-70: $purple-70 !default;
+$primary-80: $purple-80 !default;
+$primary-90: $purple-90 !default;
+$primary-95: $purple-95 !default;
+$primary-99: $purple-99 !default;
 
 $grays: () !default;
 $grays: map-merge((
@@ -80,7 +83,7 @@ $colors: map-merge((
   "gray-dark":  $gray-800
 ), $colors);
 
-$primary:       $primary-40 !default;
+$primary:       #69548D !default;
 $secondary:     $gray-600 !default;
 $success:       $green !default;
 $info:          $cyan !default;

--- a/_sass/custom/_footer.scss
+++ b/_sass/custom/_footer.scss
@@ -2,7 +2,7 @@
 .footer {
     padding-top: 50px;
     padding-bottom: 50px;
-    background-color: $primary;
+    background-color: $primary-30;
     padding-top: 40px;
     text-align: left;
     color: $white;


### PR DESCRIPTION
## Description
- Fixing mapping of primary color variables to not use hardcoded purple values.
- Add missing primary-95 and primary-99 values from figma.
- Changing footer to one darker purple tone to make it more muted for now (footer styles will later be fixed to have TBD content removed)

## Change Type
- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [X] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
AFTER:
<img width="1556" alt="Screenshot 2024-04-23 at 23 25 53" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/1acc630f-0d52-419b-a0b3-bf5caf16aa1e">

BEFORE:
<img width="1567" alt="Screenshot 2024-04-23 at 23 28 05" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/a8ccfb94-c354-4a7e-9b5c-019f533fc50f">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->