### PR TITLE
fix: Adjust about us menu

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -24,13 +24,12 @@
       url: program-interview-preparation
     - page: Study Group
       url: program-study-group
-- name: About
-  link: about
+- name: About Us
   index: 3
   subfolderitems:
-    - page: About WCC
-      url: about
     - page: Team
       url: team
+    - page: About WCC
+      url: about
     - page: Code of Conduct
       url: code-of-conduct


### PR DESCRIPTION
## Description
The correct title should be `About Us` instead of about. 

## Change Type
- [x] Bug Fix

## Screenshots
<img width="797" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/3664747/866cffdf-bffa-4be0-af45-3283dae895ae">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->