### PR TITLE
add homepage 'Join as a mentor' CTA with basic card styles

### DIFF
--- a/_sass/custom/_home.scss
+++ b/_sass/custom/_home.scss
@@ -59,13 +59,32 @@
 
 .home {
 
-    .row.bg-purple {
-        background: $primary-90;
-        padding: 0 1rem;
+    .row {
+        justify-content: center;
+        &.bg-purple {
+            background: $primary-90;
+            padding: 0 1rem;
+        }
+        h2 {
+            margin: 1rem auto;
+        }
+        .content {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            text-align: center;
+            padding: 5rem 0;
+        }
     }
 
-    .row h2 {
-        margin: 1rem auto;
+    .row.mentors-cta {
+        .btn {
+            max-width: fit-content;
+        }
+        .card-body {
+            padding: 2rem 2rem 3rem 2rem;
+            align-items: center;
+        }
     }
 
     .programs article {
@@ -93,30 +112,6 @@
         margin-top: 10px;
     }
 
-    .registration {
-        @extend .justify-content-around;
-        @extend .my-7;
-
-        ul {
-            list-style: none;
-        }
-
-        li {
-            margin-left: -37px;
-        }
-
-        span {
-            font-weight: $font-weight-bold !important;
-            font-size: larger;
-        }
-
-        .mentor {
-            @include media-breakpoint-down(sm) {
-                margin-bottom: 3em;
-            }
-        }
-    }
-
     .card-header {
         background-color: transparent;
         border: none;
@@ -131,88 +126,4 @@
             margin-bottom: 30px;
         }
     }
-
-    .timeline {
-        @extend .my-7;
-        
-        .row {
-            @extend .justify-content-around;
-            position: relative;
-
-            @include media-breakpoint-up(lg) {    
-                &::after {
-                    position: absolute;
-                    content: "";
-                    background-color: $teal;
-                    top: 50px;
-                    left: 163px;
-                    height: 4px;
-                    width: 72%;
-                    display: inline-block;
-                    z-index: -1;
-                }
-            }
-        }
-
-        .circle {
-            margin: auto;
-            height: 58px;
-            width: 58px;
-            border-radius: 50%;
-            border: 4px solid $teal;  
-            display: flex;
-            background-color: $white;
-            
-            .icon {
-                &.check {
-                    height: 50px;
-                    width: 50px;
-                }
-
-                &.heart {
-                    margin-top: 12px;
-                    height: 30px;
-                    width: 30px;
-                }
-
-                &.start {
-                    height: 30px;
-                    width: 30px;
-                }
-            }
-        }
-
-        .card-wrapper {
-            background-color: transparent;
-        }
-
-        .card-transparency {
-            background-color: transparent;
-        }
-
-        .photo {
-             width: 800px;
-         }
-
-         .bi-bell {
-            width: 86% !important;
-            padding-left: 7px;
-         }
-     }
-     
-     .feedback {
-        @extend .my-7;
-
-        .carousel-indicators li {
-             background-color: $teal;
-        }
-
-        .carousel-control-prev-icon {
-             background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='fff' viewBox='0 0 8 8'%3E%3Cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E") !important;
-        }
-     
-        .carousel-control-next-icon {
-             background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='fff' viewBox='0 0 8 8'%3E%3Cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3E%3C/svg%3E") !important;
-        }
-     }
 }

--- a/_sass/custom/media-breakpoint.scss
+++ b/_sass/custom/media-breakpoint.scss
@@ -27,9 +27,6 @@
 }
 
 @include media-breakpoint-up(l) {
-    .container {
-        max-width: 1376px;
-    }
     .page-header h1 {
         font-size: 3.5rem;
     }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -7,9 +7,16 @@ $backgroundColor: #fff;
 $bodyColor: #000000;
 $bodyFont: 'Roboto', sans-serif;
 
+$container-max-width: 1376px;
+
 body {
   background: $backgroundColor;
   color: $bodyColor;
   font-family: $bodyFont;
   font-weight: 400;
- } 
+}
+
+.container,
+.row .content {
+  max-width: $container-max-width;
+}

--- a/index.html
+++ b/index.html
@@ -7,46 +7,67 @@ title: Home
     {% include banner.html %}
 
     <div class="home">
-        <div class="row justify-content-center intro">
-            <div class="col-12 col-md-6 text-center py-6 overview">
-                <p class="lead">Empowering women in their tech careers through education, mentorship, community building, and career services is our mission. We provide workshops and events, connect members with industry mentors, foster a supportive community through meetups and conferences, and raise awareness for more inclusive industry practices.</p>
-                <a href="/about" class="btn btn-primary">Learn more about us</a>
-            </div>
-        </div>
-
-        <div class="row justify-content-center bg-purple">
-            <div class="col-12 col-md-6 text-center pt-6 pb-4 overview">
-                <h2>Opportunities & Programmes</h2>
-                <p>Discover a world of possibilities within our community. From networking events to mentorship programs and leadership opportunities, there's something for everyone to explore. Whether you're looking to sharpen your skills, expand your professional network, or take the next step in your career, we offer a wide range of opportunities to help you achieve your goals. Join us on this journey of growth and empowerment, and unlock your full potential in the tech industry.</p>
-            </div>
-            <div class="col-12 container text-center pb-6">
-                <div class="row justify-content-center programs">
-                    {% for programme in site.data.programmes %}
-                    <div class="col-12 col-md-6 col-lg-4">
-                        <article>
-                            <a href="{{ programme.url }}">
-                                <div class="material-symbols-outlined" aria-hidden="true">{{ programme.icon }}</div>
-                                <div>{{ programme.title }}</div>
-                            </a>
-                        </article>
-                    </div>
-                    {% endfor %}
+        <div class="row mission">
+            <div class="content">
+                <div class="col-12 col-md-6">
+                    <p class="lead">Empowering women in their tech careers through education, mentorship, community building, and career services is our mission. We provide workshops and events, connect members with industry mentors, foster a supportive community through meetups and conferences, and raise awareness for more inclusive industry practices.</p>
+                    <a href="/about" class="btn btn-primary">Learn more about us</a>
                 </div>
             </div>
         </div>
 
-        <div class="row justify-content-center support">
-            <div class="col-12 col-md-6 text-center py-6">
-                <h2>Meet Our Dedicated Mentors</h2>
-                <p>Ready to advance in tech? Explore our diverse mentors who are here to guide and support you on your journey.</p>
-                <a href="/mentors" class="btn btn-primary">Check our mentors</a>
+        <div class="row programmes bg-purple">
+            <div class="content">
+                <div class="col-12 col-md-6 pb-4">
+                    <h2>Opportunities & Programmes</h2>
+                    <p>Discover a world of possibilities within our community. From networking events to mentorship programs and leadership opportunities, there's something for everyone to explore. Whether you're looking to sharpen your skills, expand your professional network, or take the next step in your career, we offer a wide range of opportunities to help you achieve your goals. Join us on this journey of growth and empowerment, and unlock your full potential in the tech industry.</p>
+                </div>
+                <div class="col-12">
+                    <div class="row programs">
+                        {% for programme in site.data.programmes %}
+                        <div class="col-12 col-md-6 col-lg-4">
+                            <article>
+                                <a href="{{ programme.url }}">
+                                    <div class="material-symbols-outlined" aria-hidden="true">{{ programme.icon }}</div>
+                                    <div>{{ programme.title }}</div>
+                                </a>
+                            </article>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="row justify-content-center support bg-purple">
-            <div class="col-12 col-md-6 text-center py-6">
-                <h2>Experiencing technical issues?</h2>
-                <a href="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/new?template=bug_report.md&title=bug title" target="_blank" class="btn btn-primary">Send us a report</a>
+        <div class="row mentors-cta">
+            <div class="content">
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h2>Meet Our Dedicated Mentors</h2>
+                            <p>Ready to advance in tech? Explore our diverse mentors who are here to guide and support you on your journey.</p>
+                            <a href="/mentors" class="btn btn-primary">Check our mentors</a>    
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h2>Become a Mentor</h2>
+                            <p>Ready to empower and be empowered in tech? Become a mentor! Expand your network, give back, share expertise, and discover new perspectives.</p>
+                            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtf7-upMp1m5kJ4MSpexS-UwGJHhACEW-yPoEQoROHi4kVcg/viewform" target="_blank" class='btn btn-primary'>Join as a Mentor</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row support bg-purple">
+            <div class="content">
+                <div class="col-12">
+                    <h2>Experiencing technical issues?</h2>
+                    <a href="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/new?template=bug_report.md&title=bug title" target="_blank" class="btn btn-primary">Send us a report</a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description
Homepage section updates:
- add second 'Join as mentor' CTA
- add simple card styles to both CTAs in the row
- remove unused home styles
- refactor and remove style classes from html to reduce file size
- create max-width container variable

## Change Type
- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/74


## Screenshots
AFTER:
<img width="1570" alt="Screenshot 2024-04-25 at 14 04 44" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/a518a5c2-69b7-4983-922a-ba9c5dbfe7b6">

BEFORE:
<img width="1550" alt="Screenshot 2024-04-25 at 14 06 25" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/db287e39-4143-4476-9b47-815330d0a514">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->