### PR TITLE
Fix team contributors non-circular image shape

### DIFF
--- a/team.html
+++ b/team.html
@@ -63,7 +63,7 @@ title: Team
         <div class="row g-3">
             {% for person in site.data.collaborators %}
             <div class="col-12 col-md-6 col-lg-3">
-                <div class="contributors card">
+                <div class="card card-s">
                     <img src="{{person.image}}" alt="profile photo" class="profile photo card-img-top">
                     <div class="card-body">
                         <h5 class="card-title">{{person.name}}</h5>


### PR DESCRIPTION
## Description
Fixed missing 'card-s' class from previous code refactoring commit which caused the contributors' images to not be circular shaped.

## Change Type
- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
AFTER:
<img width="1582" alt="Screenshot 2024-04-25 at 22 44 13" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/0b621a07-66d2-40c5-b453-ddf45b42311e">

BEFORE:
<img width="1584" alt="Screenshot 2024-04-25 at 22 44 35" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/d5c69ab5-738f-43af-ab76-c907a6810c65">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->