### PR TITLE
bug: fix side-by-side card components unequal height

### DIFF
--- a/_sass/custom/_card.scss
+++ b/_sass/custom/_card.scss
@@ -32,6 +32,9 @@
 }
 
 .card-m {
+    &.card {
+        height: 100%;
+    }
     .card-header {
         background-color: transparent;
         border: none;

--- a/_sass/custom/_card.scss
+++ b/_sass/custom/_card.scss
@@ -3,7 +3,7 @@
 }
 
 .card-s {
-    .card {
+    &.card {
         height: 100%;
     }
     .card-title {

--- a/team.html
+++ b/team.html
@@ -28,24 +28,26 @@ title: Team
                         <h6 class="card-subtitle">{{person.position}}</h6>
                         <p class="card-text"><small class="text-muted">{{person.comment}}</small></p>
                     </div>
-                    <div class="card-footer">
-                        <span class="network">
-                            {% for network in person.network %}
-                                {% if network.name=="linkedin" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/linkedin.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="twitter" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/twitter.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="medium" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/medium.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="github" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/github.svg %}</a></span>
-                                {% endif %}
-                            {% endfor %}
-                        </span>
-                    </div>
+                    {% if person.network %}
+                        <div class="card-footer">
+                            <span class="network">
+                                {% for network in person.network %}
+                                    {% if network.name=="linkedin" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/linkedin.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="twitter" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/twitter.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="medium" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/medium.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="github" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/github.svg %}</a></span>
+                                    {% endif %}
+                                {% endfor %}
+                            </span>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             {% endfor %}
@@ -70,24 +72,26 @@ title: Team
                         <h6 class="card-subtitle">{{person.position}}</h6>
                         <p class="card-text"><small class="text-muted">{{person.comment}}</small></p>
                     </div>
-                    <div class="card-footer">
-                        <span class="network">
-                            {% for network in person.network %}
-                                {% if network.name=="linkedin" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/linkedin.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="twitter" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/twitter.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="medium" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/medium.svg %}</a></span>
-                                {% endif %}
-                                {% if network.name=="github" %}
-                                <span> <a href="{{network.link}}" target="_blank"> {% include icons/github.svg %}</a></span>
-                                {% endif %}
-                                    {% endfor %}
-                        </span>
-                    </div>
+                    {% if person.network %}
+                        <div class="card-footer">
+                            <span class="network">
+                                {% for network in person.network %}
+                                    {% if network.name=="linkedin" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/linkedin.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="twitter" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/twitter.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="medium" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/medium.svg %}</a></span>
+                                    {% endif %}
+                                    {% if network.name=="github" %}
+                                    <span> <a href="{{network.link}}" target="_blank"> {% include icons/github.svg %}</a></span>
+                                    {% endif %}
+                                {% endfor %}
+                            </span>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
## Description
Make team cards equal height & hide card footer when there are no networks.

Fix for open issue: [ bug: fix side-by-side card components unequal height (flexbox css issue) #133 ](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/133)

## Change Type
- [x] Bug Fix

## Screenshots
Before
![Screenshot 2024-05-01 130827](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/11363288/f145e530-774e-483e-bd90-cb96e84ebd01)
![Screenshot 2024-05-01 130641](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/11363288/027bdc45-f5e1-4749-adf3-679d8afb9407)


After
![Screenshot 2024-05-01 130631](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/11363288/79e4aea4-446a-4721-83e3-b85788abe869)
![Screenshot 2024-05-01 131641](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/11363288/8177f952-d683-4658-8987-d57269f4cd52)

