### PR TITLE
fix: Update availability and sorting of ad-hoc mentors

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -1,6 +1,6 @@
 - name: Eleonora Belova
   disabled: false
-  sort: 100
+  sort: 10
   hours: 3
   position: QA Engineer, ReaQta, an IBM Company
   type: both
@@ -28,7 +28,7 @@
 
 - name: Rajani Rao
   disabled: false
-  matched: true
+  matched: false
   sort: 200
   hours: 5
   type: both
@@ -604,6 +604,7 @@
     I'm a Recruitment professional and start-up scaling specialist. I can help mentees with the soft-skills development to really make impact in their role and in the workplace.
   image: assets/images/mentors/mona_ahluwalia.jpg
   languages: English
+  availability: [ 5 ]
   skills:
     experience: 5-7 Years
     years: 7
@@ -691,6 +692,7 @@
     ISQB-TM and ISTQB-TA certified manual and automated tester for frontend and backend teams for the last ten years; a degree in Computer Engineering; lector and author of the IT school's QA Basic and QA Pro courses; survived in an abroad company and now hold interviews there.
   image: assets/images/mentors/anastasia.jpeg
   languages: English, Ukrainian, Russian
+  availability: [ 5 ]
   skills:
     experience: 7-10 years
     years: 10
@@ -722,6 +724,7 @@
     Experienced Data Engineer with over 7 years experience in SQL, Python, AWS and BigQuery. Focus on ETL processes and data pipelines for reliable and high quality data. Currently working on data modelling and data catalogue solutions.
   image: assets/images/mentors/nonna_shakhova.jpg
   languages: English, Russian
+  availability: [ 5 ]
   skills:
     experience: 7-10 years
     years: 10


### PR DESCRIPTION
## Description
Enable registration for ad-hoc mentors and move them to the top to make easier to mentees to register.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other

## Screenshots
Before: 
<img width="1068" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/3664747/4f49194a-b3fb-4d84-a512-d9441ef866b9">


After: 
<img width="1383" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/3664747/c6c28554-2d2b-44cc-9c81-7130103159e6">
<img width="1262" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/3664747/4798a96d-c33d-41f5-9071-f64a49ec63e1">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->