### PR TITLE
fix: Include Sonali linkedin

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -134,3 +134,5 @@
   comment: Senior/Lead Engineer
   image: assets/images/team/14.jpeg
   network:
+    - name: linkedin
+      link: https://www.linkedin.com/in/sonali-goel-6b611522/


### PR DESCRIPTION
## Description
I was missing Sonali's linkedin as part of the team

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Screenshots
Before: 
<img width="1050" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/167612780/7bfd7314-4d7e-4810-9964-86c1b71f1607">


After:
<img width="1086" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/167612780/62ae36f2-68a6-4941-8193-935d7649ce8d">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->