### PR TITLE
feat: Create announcement yml and fix link

### DIFF
--- a/_data/announcement.yml
+++ b/_data/announcement.yml
@@ -1,12 +1,16 @@
 - title: Mentorship ad-hoc registration is now open for mentees
   description: Sign up for this unique opportunity of one-time mentoring sessions with personalised guidance from experienced mentors.
   date: 01.05.2024
-  image: /assets/images/announcements/stock-unsplash-computer-typing.jpg
-  link: 
+  image:
+    path: "/assets/images/announcements/stock-unsplash-computer-typing.jpg"
+    alt: Image decorative
+  link:
     path: /mentors
     title: Join now
 
 - title: New Women Coding Community website!
   description: We are thrilled to introduce our brand-new website. Created with dedication and passion by our incredible team of volunteers, this platform serves as your gateway to a diverse array of resources, programs, mentorship opportunities, and more.
   date: 30.04.2024
-  image: /assets/images/announcements/stock-copilot-designer_celebrate.jpg
+  image:
+    path: "/assets/images/announcements/stock-copilot-designer_celebrate.jpg"
+    alt: Image decorative

--- a/_data/announcement.yml
+++ b/_data/announcement.yml
@@ -1,0 +1,12 @@
+- title: Mentorship ad-hoc registration is now open for mentees
+  description: Sign up for this unique opportunity of one-time mentoring sessions with personalised guidance from experienced mentors.
+  date: 01.05.2024
+  image: /assets/images/announcements/stock-unsplash-computer-typing.jpg
+  link: 
+    path: /mentors
+    title: Join now
+
+- title: New Women Coding Community website!
+  description: We are thrilled to introduce our brand-new website. Created with dedication and passion by our incredible team of volunteers, this platform serves as your gateway to a diverse array of resources, programs, mentorship opportunities, and more.
+  date: 30.04.2024
+  image: /assets/images/announcements/stock-copilot-designer_celebrate.jpg

--- a/index.html
+++ b/index.html
@@ -43,27 +43,22 @@ title: Home
             <div class="content">
                 <h2>Announcements</h2>
                 <div class="col-12 col-lg-8">
-                    <article class="card card-l">
-                        <div class="card-body col-md-8">
-                            <div class="card-date">01.05.2024</div>
-                            <h3 class="card-title">Mentorship ad-hoc registration is now open for mentees</h3>
-                            <p class="card-desc">Sign up for this unique opportunity of one-time mentoring sessions with personalised guidance from experienced mentors.</p>
-                            <a href="https://docs.google.com/forms/d/e/1FAIpQLSeoMLS2K-DYF16uXALXrJtHJMqQZSNDYcFh0nYmBFV2GHM6ig/viewform" target="_blank" class="btn btn-outline-primary">Join now</a>
-                        </div>
-                        <div class="card-media col-md-4">
-                            <img src="/assets/images/announcements/stock-unsplash-computer-typing.jpg">
-                        </div>
-                    </article>
-                    <article class="card card-l">
-                        <div class="card-body col-md-8">
-                            <div class="card-date">30.04.2024</div>
-                            <h3 class="card-title">New Women Coding Community website!</h3>
-                            <p class="card-desc">We are thrilled to introduce our brand-new website. Created with dedication and passion by our incredible team of volunteers, this platform serves as your gateway to a diverse array of resources, programs, mentorship opportunities, and more.</p>
-                        </div>
-                        <div class="card-media col-md-4">
-                            <img src="/assets/images/announcements/stock-copilot-designer_celebrate.jpg">
-                        </div>
-                    </article>
+                    {% for announcement in site.data.announcement %}
+                        <article class="card card-l">
+                            <div class="card-body col-md-8">
+                                <div class="card-date">{{ announcement.date }}</div>
+                                <h3 class="card-title">{{ announcement.title }}</h3>
+                                <p class="card-desc">{{ announcement.description }}</p>
+                                {% if announcement.link %}
+                                    <a href="{{ announcement.link.path }}" class="btn btn-outline-primary">{{ announcement.link.title }}</a>
+                                {% endif %}
+                            </div>
+                            
+                            <div class="card-media col-md-4">
+                                <img src="{{ announcement.image }}" alt="{{ announcement.title }} image">
+                            </div>
+                        </article>
+                    {% endfor %}
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -44,20 +44,21 @@ title: Home
                 <h2>Announcements</h2>
                 <div class="col-12 col-lg-8">
                     {% for announcement in site.data.announcement %}
-                        <article class="card card-l">
-                            <div class="card-body col-md-8">
-                                <div class="card-date">{{ announcement.date }}</div>
-                                <h3 class="card-title">{{ announcement.title }}</h3>
-                                <p class="card-desc">{{ announcement.description }}</p>
-                                {% if announcement.link %}
-                                    <a href="{{ announcement.link.path }}" class="btn btn-outline-primary">{{ announcement.link.title }}</a>
-                                {% endif %}
-                            </div>
-                            
-                            <div class="card-media col-md-4">
-                                <img src="{{ announcement.image }}" alt="{{ announcement.title }} image">
-                            </div>
-                        </article>
+                    <article class="card card-l">
+                        <div class="card-body col-md-8">
+                            <div class="card-date">{{ announcement.date }}</div>
+                            <h3 class="card-title">{{ announcement.title }}</h3>
+                            <p class="card-desc">{{ announcement.description }}</p>
+                            {% if announcement.link %}
+                            <a href="{{ announcement.link.path }}" class="btn btn-outline-primary">{{
+                                announcement.link.title }}</a>
+                            {% endif %}
+                        </div>
+
+                        <div class="card-media col-md-4">
+                            <img src="{{ announcement.image.path }}" alt="{{ announcement.image.alt }}">
+                        </div>
+                    </article>
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
## Description

In order to simply updates in announcement's session, we moved the content to yml and simply the logic in the html page.

Instead of open mentee registration, it should go to mentor list to select the mentor. 

## Change Type
- [x] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other

## Screenshots
New pages stays the same: 
<img width="964" alt="image" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/167612780/4ec61ad4-67af-4ae8-859a-fdc3ffe4ce37">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->