### PR TITLE
Fix dropdown nav to stay open on click

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -2,9 +2,10 @@
   link: #empty because now using absolute paths
   index: 0
 - name: Mentorship
-  link: mentorship
   index: 1
   subfolderitems:
+    - page: Overview
+      url: mentorship
     - page: Mentors
       url: mentors
     - page: Resources
@@ -26,9 +27,10 @@
   link: blog
   index: 3
 - name: About Us
-  link: about
   index: 4
   subfolderitems:
+    - page: Overview
+      url: about
     - page: Team
       url: team
     - page: Code of Conduct

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -16,8 +16,8 @@
                     {% if item.subfolderitems %}
 
                         {% if item.link %}
-                            <a class="nav-link" id="drop{{item.index}}" href="/{{item.link}}" aria-haspopup="true" aria-expanded="false">
-                            <span class="dropdown-toggle">{{ item.name }}</span>
+                            <a class="nav-link" id="drop{{item.index}}" href="/{{item.link}}" role="button" aria-haspopup="true" aria-expanded="false">
+                                <span class="dropdown-toggle">{{ item.name }}</span>
                             </a>
                         {% else %}
                             <a data-target="#" data-toggle="dropdown" class="nav-link cursor-pointer" id="drop{{item.index}}" aria-haspopup="true" aria-expanded="false">
@@ -28,10 +28,10 @@
                         <ul class="dropdown-menu{% if forloop.last %} dropdown-menu-right{% endif %}" aria-labelledby="drop{{item.index}}">
                             {% for entry in item.subfolderitems %}
                                 <li>
-                                    <a class="nav-link" href="/{{ entry.url }}">{{ entry.page }}</a>
+                                    <a class="dropdown-item" href="/{{ entry.url }}">{{ entry.page }}</a>
                                 </li>
                             {% endfor %}
-                          </ul>
+                        </ul>
                     {% else %}
                         <a class="nav-link" id="nav-{{item.index}}" href="/{{item.link}}">{{ item.name }}</a>
                     {% endif %}

--- a/_sass/custom/_menu.scss
+++ b/_sass/custom/_menu.scss
@@ -21,19 +21,19 @@
     }
   }
 
-  .navbar li {
+  .nav-item {
     list-style-type: none;
     display: inline-block;
     margin: 0.2rem 1rem;
   }
     
-  .navbar li > a {
+  .nav-item > a {
     text-decoration: none;
     display: inline-block;
     position: relative;
   }
   
-  .navbar li > a::after {
+  .nav-item > a::after {
     content: "";
     display: block;
     margin: auto;
@@ -44,7 +44,7 @@
     transition: all 0.3s;
   }
     
-  .navbar li > a:hover::after, li > a.active-nav::after {
+  .nav-item > a:hover::after, li > a.active-nav::after {
     width: 100%;
     background: $primary;
   }
@@ -53,8 +53,15 @@
     background: transparent;
   }
 
-  .dropdown-menu li {
-    display: block;
+  .dropdown-menu {
+    padding: 0;
+    li {
+      display: block;
+    }
+  }
+
+  .dropdown-item {
+    padding: 0.5rem 1rem;
   }
 
   @include media-breakpoint-down(lg) { 

--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -20,13 +20,22 @@ const controllerNavbar = (function (jQuery) {
       const dropdownToggle = dropdownMenu.find('.dropdown-toggle');
       const dropdownMenuContent = dropdownMenu.find('.dropdown-menu');
 
-      dropdownToggle.on('mouseenter', function () {
-        dropdownMenuContent.addClass('show');
-      })
+      // Toggle dropdown menu when clicking the dropdown toggle
+      dropdownToggle.on('click', function (e) {
+        e.preventDefault(); // Prevent default anchor behavior
+        
+        // Close all other dropdowns
+        jQuery('.dropdown-menu').not(dropdownMenuContent).removeClass('show');
+        
+        dropdownMenuContent.toggleClass('show');
+      });
 
-      dropdownMenu.on('mouseleave', function () {
-        dropdownMenuContent.removeClass('show');
-      })
+      // Hide dropdown menu when clicking outside the dropdown menu
+      jQuery(document).on('click', function (e) {
+        if (!dropdownMenu.is(e.target) && dropdownMenu.has(e.target).length === 0 && !dropdownToggle.is(e.target) && dropdownToggle.has(e.target).length === 0) {
+          dropdownMenuContent.removeClass('show');
+        }
+      });
     });
   }
 


### PR DESCRIPTION
## Description
- fixed dropdown usability by changing the nav to always stay open on click
- added missing 'Overview' links for Mentorship and About Us landing pages
- increase dropdown links paddings to make it easier to target the child links

## Change Type
- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/115

## Screenshots
AFTER:
<img width="1545" alt="Screenshot 2024-05-07 at 22 58 10" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/a2b6fd5f-db6c-45fd-8a82-f4d0e8a2d9ee">

BEFORE:
<img width="1542" alt="Screenshot 2024-05-07 at 23 01 48" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/26842896/9a3b7479-c02c-4c5e-b483-5089e28abb96">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->