### PR TITLE
Adjust default ad-hoc registration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ plugins:
 sass:
   sass_dir: _sass/
 
-registration: 12
+registration: 10
 
 # Settings
 title: "Women Coding Community"


### PR DESCRIPTION
The default config will be 10 days open for registration

## Description
The registration should be only 10 days. 


## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [ ] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->