### PR TITLE
Remove unnessary bootstrap font variable overrides

### DIFF
--- a/_sass/custom/_variables.scss
+++ b/_sass/custom/_variables.scss
@@ -107,39 +107,22 @@ $link-color: $primary-40;
 $text-primary: $black;
 $text-secondary: $neutral-40;
 
-// bootstrap overrides
-$display1-size: 3.6rem;
-$display2-size: 2.8rem;
-$display3-size: 2.25rem;
+$font-display-l: 3.6rem;
+$font-display-m: 2.8rem;
+$font-display-s: 2.25rem;
 
-$font-display-l: $display1-size;
-$font-display-m: $display2-size;
-$font-display-s: $display3-size;
+$font-headline-l: 2rem;
+$font-headline-m: 1.74rem;
+$font-headline-s: 1.5rem;
 
-$h1-font-size: 2rem;
-$h2-font-size: 1.74rem;
-$h3-font-size: 1.5rem;
+$font-title-l: 1.375rem;
+$font-title-m: 1rem;
+$font-title-s: 0.875rem;
 
-$font-headline-l: $h1-font-size;
-$font-headline-m: $h2-font-size;
-$font-headline-s: $h3-font-size;
+$font-body-l: 1.25rem;
+$font-body-m: 1rem;
+$font-body-s: 0.875rem;
 
-$h4-font-size: 1.375rem;
-$h5-font-size: 1rem;
-$h6-font-size: 0.875rem;
-
-$font-title-l: $h4-font-size;
-$font-title-m: $h5-font-size;
-$font-title-s: $h6-font-size;
-
-$font-size-lg: 1.25rem;
-$font-size-md: 1rem;
-$font-size-sm: 0.875rem;
-
-$font-body-l: $font-size-lg;
-$font-body-m: $font-size-md;
-$font-body-s: $font-size-sm;
-
-$font-label-l: $font-size-md;
-$font-label-m: $font-size-sm;
+$font-label-l: 1rem;
+$font-label-m: 0.875rem;
 $font-label-s: 0.6875rem;


### PR DESCRIPTION
## Description
Bootstrap overrides not needed, and it's confusing having them 'mixed together' with the new font variables - which are the ones that should be used from now on.

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [X] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [ ] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->