### PR TITLE
Automate mentors.yml - small update for ad-hoc type

### DIFF
--- a/tools/automation.py
+++ b/tools/automation.py
@@ -28,7 +28,7 @@ FOCUS_END_INDEX = 22
 PROG_LANG_START_INDEX = 23
 PROG_LANG_END_INDEX = 27
 
-TYPE_AD_HOC = "ad hoc"
+TYPE_AD_HOC = "ad-hoc"
 TYPE_LONG_TERM = "long-term"
 TYPE_BOTH = "both"
 IMAGE_FILE_PATH = "assets/images/mentors"
@@ -134,7 +134,7 @@ def get_mentorship_type(mentorship_type_str):
     mentorship_type = mentorship_type_str.lower()
 
     if TYPE_AD_HOC in mentorship_type:
-        return TYPE_AD_HOC.replace(' ', '-')
+        return TYPE_AD_HOC
     elif TYPE_LONG_TERM in mentorship_type:
         return TYPE_LONG_TERM
     elif TYPE_BOTH in mentorship_type:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
In new mentors xlsx table the "ad hoc" type is now written as "Ad-Hoc" and not as "Ad Hoc". The same format is also updated in the code.

<!--- Why is this change required? What problem does it solve? -->
Since the check of the type was done using the "ad hoc" string, the "ad-hoc" was not recognized and the type: NOT_FOUND was displayed in the mentors.yml.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/130

## Change Type
- [x] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->