### PR TITLE
Add email to code of conduct page

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -37,7 +37,7 @@ body_class: page page-code-of-conduct
             </section>
             <section>
                 <h2>Enforcement:</h2>
-                <p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. Instances of abusive, harassing, or otherwise unacceptable behavior can be reported by completing our [INCIDENT_REPORT_FORM]. All complaints will be reviewed and investigated promptly and fairly.</p>
+                <p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. Instances of abusive, harassing, or otherwise unacceptable behavior can be reported by <a href="mailto:london@womencodingcommunity.com">email</a>. All complaints will be reviewed and investigated promptly and fairly.</p>
             </section>
             <section>
                 <h2>Consequences:</h2>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes [issue 228](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/228) by adding the missing email to the code of conduct page under the Enforcement section. I changed the copy slightly to reflect that the user should email the team rather than complete a form. 

<img width="402" alt="Screenshot 2024-06-01 at 22 41 33" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/49168984/f66b66bc-ca13-4eae-bf8e-e72daff4606a">


## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->