### PR TITLE
bug-fix: Wrong alignment with plus (+) icon #248

### DIFF
--- a/_sass/custom/_accordion.scss
+++ b/_sass/custom/_accordion.scss
@@ -30,7 +30,7 @@
 
         .accordion-icon {
             position: relative; 
-            margin-left: auto; /* move icon to the right */
+            margin-left: auto; 
 
             svg {
                 width: 2rem;

--- a/_sass/custom/_accordion.scss
+++ b/_sass/custom/_accordion.scss
@@ -9,6 +9,7 @@
 
         .accordion-header {
             position: relative;
+            display: flex; 
         }
 
         .accordion-body {
@@ -28,9 +29,8 @@
         }
 
         .accordion-icon {
-            position: absolute;
-            top: 0;
-            right: 0;
+            position: relative; 
+            margin-left: auto; /* move icon to the right */
 
             svg {
                 width: 2rem;


### PR DESCRIPTION
## Description
The plus (+) icon bullet points are misaligned with the texts in Safari.
[reported issue](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/issues/248)

This bug happened in Safari and Firefox browsers (reproduced by @dricazenck)  

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other

## Screenshots
*before*
<img width="869" alt="Screenshot 2024-05-30 at 09 34 52" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/17250560/1608373c-ae32-461d-9675-2fcfae628d41">
<img width="865" alt="Screenshot 2024-06-01 at 18 16 56" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/17250560/18c49b1d-799c-49c9-a6f2-9dd360e87899">


*after*
<img width="1421" alt="Screenshot 2024-06-02 at 09 09 18" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/17250560/64102a14-0600-47df-83a0-40ebac586b06">
<img width="1432" alt="Screenshot 2024-06-02 at 09 09 29" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/17250560/8588c426-985e-45f6-bd82-e4f2a2ddf203">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 