### PR TITLE
ad-hoc registration disabled for Sonali

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -231,7 +231,7 @@
 - name: Sonali Goel
   disabled: false
   matched: false
-  sort: 100
+  sort: 10
   hours: 1
   position: Lead Engineer, Yoox-Net-A-Porter
   type: both
@@ -241,7 +241,7 @@
     Sonali serves as a Lead Engineer at Yoox-Net-a-porter, specializing in managing and constructing extensive-scale ecommerce solutions. She leverages Java-based commerce platforms and integrates them with open-source technologies like Spring Boot and Spring Batch. As an AWS-certified Solution Architect, she possesses deep knowledge of Amazon Web Services, complemented by proficiency in implementing continuous integration and continuous deployment (CICD) practices to ensure seamless software delivery. Additionally, she excels in architecting and implementing microservices-based architectures to drive agility and modularity in software development With over 13 years of experience in the technology industry, Sonali brings a wealth of expertise in steering technical direction and fostering high-performance outcomes. Her passion lies in nurturing a culture of continuous learning and innovation. Outside of her professional endeavors, Sonali actively volunteers with Women Who Code, advocating for gender diversity. She is also a creative enthusiast, utilizing design templates to convey ideas, thoughts, and emotions visually.
   image: assets/images/mentors/sonali_goel.jpg
   languages: English
-  availability: [ 6 ]
+  availability: [ ]
   skills:
     experience: 10-15 Years
     years: 15


### PR DESCRIPTION
## Description
Ad-hoc registration disabled for Sonali as one mentee matched.
Number of hours available for June = 1

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [x] Mentor Update
- [ ] Documentation
- [ ] Other

## Screenshots
**Before**
![image](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/101481898/1ab39667-74ee-4481-ab68-e08e1b378a95)

**After**
![image](https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/101481898/cf0f2351-5c76-461f-8e9e-04985212a876)


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->