### PR TITLE
Bug Fix: Mentor Search functionality

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -533,7 +533,7 @@
     - linkedin: https://www.linkedin.com/in/ceri-shaw/
 
 - name: Minsang Kim
-  disabled: false
+  disabled: true
   sort: 100
   hours: 4
   position: CTO/Co-founder (previously Machine Learning Scientist at Amazon), Radiant AI
@@ -843,7 +843,6 @@
     extra: Preparation for Technical interviews, Project review
   network:
     - linkedin: https://www.linkedin.com/in/sahana-venkatesh/
-
 
 - name: Agrin Hilmkil
   disabled: false
@@ -1225,14 +1224,14 @@
     mentee: |
       Who are preparing for interviews, want to enter IT or web3 world
     areas:
-    - Data Science
-    - Data Engineering
-    - Distributed Systems
+      - Data Science
+      - Data Engineering
+      - Distributed Systems
     languages: Python, Java, C++
     focus:
-    - Switch career to IT
-    - Grow from mid-level to senior-level
-    - Grow from beginner to mid-level
+      - Switch career to IT
+      - Grow from mid-level to senior-level
+      - Grow from beginner to mid-level
     extra: |
       1. Data Science and Machine Learning: Techniques, best practices, and real-world applications.
       2. Fraud Detection and Prevention: Strategies and model implementation for reducing fraud.
@@ -1240,5 +1239,5 @@
       4. Project Management: Agile methodologies, team collaboration, and stakeholder management.
       5. Technical Skills Enhancement: Advanced Python, SQL, and AWS.
   network:
-  - linkedin: https://www.linkedin.com/in/jyoti-y-b8232969/
-  - medium: https://medium.com/@jyotiyadav99111
+    - linkedin: https://www.linkedin.com/in/jyoti-y-b8232969/
+    - medium: https://medium.com/@jyotiyadav99111

--- a/mentors.html
+++ b/mentors.html
@@ -19,111 +19,115 @@ body_class: page search-page list-page-mentors
             {% assign current_day = site.time | date: "%d" | plus: 0 %}
             {% assign current_month = site.time | date: "%-m" | plus: 0 %}
 
-            {% assign mentors = site.data.mentors| where: 'disabled', false | sort: "sort" | reverse %}
+            {% assign mentors = site.data.mentors| sort: "sort" | reverse %}
 
             {% for mentor in mentors %}
-            <div class="card card-mentor" id="mentor-card-{{mentor.index}}">
-                <div class="row col-12">
-                    <div class="card-media col-md-3">
-                        <img src="{{mentor.image}}" alt="mentor headshot">
-                        {% include registration.html %}
-                    </div>
-                    <div class="card-content col-md-9">
-                        <div class="card-header">
-                            <ul class="nav nav-tabs card-header-tabs">
-                                <li class="nav-item">
-                                    <div class="nav-link active presentation" id="bt-p-{{mentor.index}}" data-index="{{mentor.index}}">Presentation</div>
-                                </li>
-                                <li class="nav-item">
-                                    <div class="nav-link skills" data-index="{{mentor.index}}" id="bt-s-{{mentor.index}}">Skills</div>
-                                </li>
-                                <li class="nav-item">
-                                    <div class="nav-link mentees" data-index="{{mentor.index}}" id="bt-m-{{mentor.index}}">Mentees</div>
-                                </li>
-                                <li class="nav-item">
-                                    <div class="nav-link reviews" data-index="{{mentor.index}}" id="bt-v-{{mentor.index}}">Reviews</div>
-                                </li>
-                                <li class="nav-item">
-                                    <div class="nav-link mentor-resources" data-index="{{mentor.index}}" id="bt-r-{{mentor.index}}">Resources</div>
-                                </li>
-                            </ul>
-                        </div>
+                {% if mentor.disabled %}
+                    <div class="inactive-mentor" id="mentor-card-{{mentor.index}}"></div>
+                {% else %}
+                    <div class="card card-mentor" id="mentor-card-{{mentor.index}}">
+                        <div class="row col-12">
+                            <div class="card-media col-md-3">
+                                <img src="{{mentor.image}}" alt="mentor headshot">
+                                {% include registration.html %}
+                            </div>
+                            <div class="card-content col-md-9">
+                                <div class="card-header">
+                                    <ul class="nav nav-tabs card-header-tabs">
+                                        <li class="nav-item">
+                                            <div class="nav-link active presentation" id="bt-p-{{mentor.index}}" data-index="{{mentor.index}}">Presentation</div>
+                                        </li>
+                                        <li class="nav-item">
+                                            <div class="nav-link skills" data-index="{{mentor.index}}" id="bt-s-{{mentor.index}}">Skills</div>
+                                        </li>
+                                        <li class="nav-item">
+                                            <div class="nav-link mentees" data-index="{{mentor.index}}" id="bt-m-{{mentor.index}}">Mentees</div>
+                                        </li>
+                                        <li class="nav-item">
+                                            <div class="nav-link reviews" data-index="{{mentor.index}}" id="bt-v-{{mentor.index}}">Reviews</div>
+                                        </li>
+                                        <li class="nav-item">
+                                            <div class="nav-link mentor-resources" data-index="{{mentor.index}}" id="bt-r-{{mentor.index}}">Resources</div>
+                                        </li>
+                                    </ul>
+                                </div>
 
-                        <h4 class="card-title">
-                            {{mentor.name}}
-                        </h4>
+                                <h4 class="card-title">
+                                    {{mentor.name}}
+                                </h4>
 
-                        <div id="presentation-{{mentor.index}}" class="card-presentation" data-index="{{mentor.index}}">
-                            <h5 class="position">{{mentor.position}}</h5>
-                            <p><label>Based in</label>: {{mentor.location}}</p>
-                            <p id="card-text-{{mentor.index}}" class="card-text content-justify content-overflow"><label>Bio</label>: {{mentor.bio}}</p>
-                            <button id="btn-show-more-{{mentor.index}}" class="btn btn-show-more btn-outline-primary toggle-content">Show more</button>
-                        </div>
+                                <div id="presentation-{{mentor.index}}" class="card-presentation" data-index="{{mentor.index}}">
+                                    <h5 class="position">{{mentor.position}}</h5>
+                                    <p><label>Based in</label>: {{mentor.location}}</p>
+                                    <p id="card-text-{{mentor.index}}" class="card-text content-justify content-overflow"><label>Bio</label>: {{mentor.bio}}</p>
+                                    <button id="btn-show-more-{{mentor.index}}" class="btn btn-show-more btn-outline-primary toggle-content">Show more</button>
+                                </div>
 
-                        <div id="skills-{{mentor.index}}" class="card-skills d-none">
-                            <p><label>Tech Experience</label>: {{mentor.skills.experience}}</p>
-                            <p><label>Language(s)</label>: {{mentor.languages}}</p>
+                                <div id="skills-{{mentor.index}}" class="card-skills d-none">
+                                    <p><label>Tech Experience</label>: {{mentor.skills.experience}}</p>
+                                    <p><label>Language(s)</label>: {{mentor.languages}}</p>
 
-                            {% if mentor.skills.languages %}
-                                <p><label>Programming languages</label>: {{mentor.skills.languages}}</p>
-                            {% endif %}
+                                    {% if mentor.skills.languages %}
+                                        <p><label>Programming languages</label>: {{mentor.skills.languages}}</p>
+                                    {% endif %}
 
-                            {% include networks_mentors.html %}
-                        </div>
+                                    {% include networks_mentors.html %}
+                                </div>
 
-                        <div id="mentees-{{mentor.index}}" class="card-mentees d-none">
-                            <p data-toggle="tooltip" data-html="true" title="<b>Ad-Hoc:</b> request a session when necessary. <br><b>Long term relationship:</b> at least one mentoring program cycle.">
-                                <label>Type of mentoring</label>:
-                                {% assign mentor_type_lower = mentor.type | downcase %}
-                                {% if mentor_type_lower == 'both' %}
-                                    Long term relationship and Ad-Hoc
-                                {% elsif mentor_type_lower == 'long-term' %}
-                                    Long term relationship
-                                {% elsif mentor_type_lower == 'ad-hoc' %}
-                                    Ad-Hoc
-                                {% else %}
-                                    {{mentor.type}}
-                                {% endif %}
-                                <span>{% include icons/question-fill.svg %}</span>
-                            </p>
-                            {% if mentor.hours > 0 %}
-                                <p class="card-text content-justify"><label>Hours available per month</label>: {{mentor.hours}}</p>
-                            {% endif %}
-                            <p class="card-text content-justify"><label>Ideal Mentee</label>: {{mentor.skills.mentee}}</p>
-                            <p>
-                                <label>Areas to support the mentee</label>:
-                                <ul>
-                                    {% for area in mentor.skills.areas %}
-                                        {% if area != nil %}
-                                            <li>{{area}}</li>
+                                <div id="mentees-{{mentor.index}}" class="card-mentees d-none">
+                                    <p data-toggle="tooltip" data-html="true" title="<b>Ad-Hoc:</b> request a session when necessary. <br><b>Long term relationship:</b> at least one mentoring program cycle.">
+                                        <label>Type of mentoring</label>:
+                                        {% assign mentor_type_lower = mentor.type | downcase %}
+                                        {% if mentor_type_lower == 'both' %}
+                                            Long term relationship and Ad-Hoc
+                                        {% elsif mentor_type_lower == 'long-term' %}
+                                            Long term relationship
+                                        {% elsif mentor_type_lower == 'ad-hoc' %}
+                                            Ad-Hoc
+                                        {% else %}
+                                            {{mentor.type}}
                                         {% endif %}
-                                    {% endfor %}
-                                    {% for focus in mentor.skills.focus %}
-                                        <li>{{focus}}</li>
-                                    {% endfor %}
-                                </ul>
-                            </p>
-                            {% if mentor.skills.extra %}
-                                <p><label>Other potential mentoring topics</label>: {{mentor.skills.extra}}</p>
-                            {% endif %}
+                                        <span>{% include icons/question-fill.svg %}</span>
+                                    </p>
+                                    {% if mentor.hours > 0 %}
+                                        <p class="card-text content-justify"><label>Hours available per month</label>: {{mentor.hours}}</p>
+                                    {% endif %}
+                                    <p class="card-text content-justify"><label>Ideal Mentee</label>: {{mentor.skills.mentee}}</p>
+                                    <p>
+                                        <label>Areas to support the mentee</label>:
+                                        <ul>
+                                            {% for area in mentor.skills.areas %}
+                                                {% if area != nil %}
+                                                    <li>{{area}}</li>
+                                                {% endif %}
+                                            {% endfor %}
+                                            {% for focus in mentor.skills.focus %}
+                                                <li>{{focus}}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </p>
+                                    {% if mentor.skills.extra %}
+                                        <p><label>Other potential mentoring topics</label>: {{mentor.skills.extra}}</p>
+                                    {% endif %}
+                                </div>
+
+                                {% include review_mentors.html %}
+
+                                {% include resources_mentors.html %}
+                            </div>
                         </div>
-
-                        {% include review_mentors.html %}
-
-                        {% include resources_mentors.html %}
+                        <input type="hidden" name="index" value="{{mentor.index}}">
+                        <input type="hidden" name="exp" value="{{mentor.skills.years}}">
+                        <input type="hidden" name="mentor-type" value="{{mentor.type | downcase}}">
+                        <input type="hidden" name="mentor-data"
+                            value="{{mentor.name | downcase}}
+                                {{mentor.bio | normalize_whitespace | downcase}}
+                                {{mentor.skills.languages | downcase}}
+                                {{mentor.skills.extra | normalize_whitespace | downcase}}
+                                {{mentor.skills.focus | array_to_sentence_string | downcase}}
+                                {{mentor.skills.areas | array_to_sentence_string | downcase}}">
                     </div>
-                </div>
-                <input type="hidden" name="index" value="{{mentor.index}}">
-                <input type="hidden" name="exp" value="{{mentor.skills.years}}">
-                <input type="hidden" name="mentor-type" value="{{mentor.type | downcase}}">
-                <input type="hidden" name="mentor-data"
-                    value="{{mentor.name | downcase}}
-                        {{mentor.bio | normalize_whitespace | downcase}}
-                        {{mentor.skills.languages | downcase}}
-                        {{mentor.skills.extra | normalize_whitespace | downcase}}
-                        {{mentor.skills.focus | array_to_sentence_string | downcase}}
-                        {{mentor.skills.areas | array_to_sentence_string | downcase}}">
-            </div>
+                {% endif %}   
         {% endfor %}
         </div>
     </div>

--- a/mentors.html
+++ b/mentors.html
@@ -9,11 +9,11 @@ body_class: page search-page list-page-mentors
 <div class="container">
     <div class="row">
         <div class="row-content col-12 col-lg-10">
-            <div id="no-mentors-msg" class="alert alert-info d-none" role="alert">
+            {% include search-results-header.html %}
+
+            <div id="no-mentors-msg" class="alert alert-info d-none mb-5" role="alert">
                 Sorry, no mentors matching your search criteria were found. Please, adjust your filters and try again.
             </div>
-
-            {% include search-results-header.html %}
 
             {% assign days_open = site.registration | plus: 0 %}
             {% assign current_day = site.time | date: "%d" | plus: 0 %}


### PR DESCRIPTION
## Description
This PR fixes the bug in mentors' search where it shows the last indexed mentor instead of no results when you search for a profile that does not exist.
This was caused by the change in how deactivated mentors are displayed. Because the search logic currently relies heavily on mentors' indexes, deactivated mentors cannot be filtered out of the list of mentors in the html file - it messes with the indexing in the for loops.

**Fix:** Revert back to previous html view where deactivated mentors are still indexed but their cards have `display: none`.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Documentation
- [ ] Other

## Related Issue
resolves #260 

## Screenshots
### Before:
a) this should show 'no mentors' box instead
<img width="1086" alt="Screenshot 2024-06-06 at 6 52 55 am" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/38109438/173817d1-b5d7-4835-9d09-a87a64b45b9e">

b) this should only show Adriana
<img width="1086" alt="Screenshot 2024-06-06 at 6 53 09 am" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/38109438/49e1fb0c-801e-436d-85d3-696338337835">

### After
a)
<img width="1086" alt="Screenshot 2024-06-06 at 6 49 42 am" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/38109438/d15d27aa-83bb-4e1c-aaaa-99dac35d8b4f">

b)
<img width="1086" alt="Screenshot 2024-06-06 at 6 49 55 am" src="https://github.com/WomenCodingCommunity/WomenCodingCommunity.github.io/assets/38109438/58a9dd9e-8bab-47f3-8a1d-9a1bae89e350">


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->