### PR TITLE
Upcoming Events should expire on the event day, not 1 day after

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -5,7 +5,7 @@
   category: category-book-club
   category_name: Book Club
   date: THU, MAY 30, 2024
-  expiration: "20240531"
+  expiration: "20240530"
   host: "Silke Nodwell and Irina Kamalova"
   time: 8:00 PM to 9:30 PM CEST
   image:
@@ -23,7 +23,7 @@
   category: category-tech-talk
   category_name: Tech Talk
   date: THU, JUN 6, 2024
-  expiration: "20240607"
+  expiration: "20240606"
   speaker: "Sonali Goel, Senior/Lead Engineer"
   time: 8:00 PM to 9:30 PM CEST
   image:
@@ -41,7 +41,7 @@
   category: category-writing-club
   category_name: Writing Club
   date: THU, JUN 13, 2024
-  expiration: "20240614"
+  expiration: "20240613"
   host: "Julia Babahina and Irina Kamalova"
   time: 8:00 PM to 9:00 PM CEST
   image:
@@ -60,7 +60,7 @@
   category: category-tech-talk
   category_name: Tech Talk
   date: WED, JUL 3, 2024
-  expiration: "20240704"
+  expiration: "20240703"
   speaker: "Lasha Dolenjashvili, Data Solutions Architect"
   time: 8:00 PM to 9:30 PM CEST
   image:
@@ -78,7 +78,7 @@
   category: category-coding-club
   category_name: Coding Club
   date: THU, JUL 4, 2024
-  expiration: "20240705"
+  expiration: "20240704"
   host: "Nonna Shakhova and Irina Kamalova"
   time: 8:00 PM to 10:0 PM CEST
   image:
@@ -96,7 +96,7 @@
   category: category-writing-club
   category_name: Writing Club
   date: THU, JUL 11, 2024
-  expiration: "20240712"
+  expiration: "20240711"
   host: "Julia Babahina and Irina Kamalova"
   time: 8:00 PM to 9:00 PM CEST
   image:
@@ -115,7 +115,7 @@
   category: category-tech-talk
   category_name: Tech Talk
   date: WED, JUL 17, 2024
-  expiration: "20240718"
+  expiration: "20240717"
   speaker: "Madhura Chaganty, Engineering Manager"
   time: 8:00 PM to 10:00 PM CEST
   image:
@@ -133,7 +133,7 @@
   category: category-career-talk
   category_name: Career Talk
   date: TUE, JUL 23, 2024
-  expiration: "20240724"
+  expiration: "20240723"
   speaker: "Nadia Edwards-Dashti, Co-Founder of Harrington Starr Group"
   time: 8:00 PM to 9:30 PM CEST
   image:


### PR DESCRIPTION
## Description
Fixes bug where Events still show up as upcoming event the day after - they should have expiration date of the event day, not after


## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue

## Screenshots
Before: (on 5th July)
<img width="1440" alt="Screenshot 2024-07-05 at 6 19 33 pm" src="https://github.com/Women-Coding-Community/WomenCodingCommunity.github.io/assets/38109438/38f48f1d-9000-4657-876f-2fdc2cb23f96">

After (on 5th July)
<img width="1440" alt="Screenshot 2024-07-05 at 6 19 02 pm" src="https://github.com/Women-Coding-Community/WomenCodingCommunity.github.io/assets/38109438/3e9b1d4b-210c-404f-9478-e7322d759ce1">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->