### PR TITLE
Copy mentor alert fix

### DIFF
--- a/_includes/share-mentor.html
+++ b/_includes/share-mentor.html
@@ -2,6 +2,7 @@
 {% assign mentor_name = mentor.name %} 
 {% assign full_url = base_url | append: '/mentors?keywords=' | append: mentor_name %}
 
+<div class="mentor-container">
 <span class="link-copied-alert alert alert-info d-none" role="alert">
     Link Copied.
  </span> 
@@ -21,4 +22,5 @@
         </a>
     </li>
 </ul>
+</div>
 

--- a/assets/js/mentors.js
+++ b/assets/js/mentors.js
@@ -7,7 +7,6 @@ var controllerMentors = (function(jQuery) {
     var tooltip = jQuery('[data-toggle="tooltip"]');
     var toggleContent = jQuery('.toggle-content');
     var copyLink = jQuery('.copy-link');
-    var linkCopiedAlert = jQuery('.link-copied-alert');
 
 
     const CLASS_ACTIVE = 'active';
@@ -145,6 +144,9 @@ var controllerMentors = (function(jQuery) {
             tempInput.val(text).select();
             document.execCommand("copy");
             tempInput.remove();
+
+            var mentorContainer = jQuery(this).closest('.mentor-container');
+            var linkCopiedAlert = mentorContainer.find('.link-copied-alert')
       
             linkCopiedAlert.removeClass(CLASS_HIDDEN);
             setTimeout(function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The "Link Copied" alert was displaying for all mentors when the copy link was clicked for a specific mentor. This PR fixes the issue by ensuring the alert shows only for the mentor whose link was copied.


## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->

Before
<img width="1313" alt="Screenshot 2024-07-13 at 21 18 25" src="https://github.com/user-attachments/assets/8743ad99-a7d3-4731-a615-933195e4a6dd">

After
![image](https://github.com/user-attachments/assets/156df0a9-65a0-45f7-a0ea-e71e9a0f59dd)


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->