### PR TITLE
Update Ad-hoc registration open days

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ plugins:
 sass:
   sass_dir: _sass/
 
-registration: 10
+registration: 13
 
 # Settings
 title: "Women Coding Community"

--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -79,7 +79,7 @@
   type: both
   index: 3
   languages: Portuguese, English
-  availability: [ 9, 10, 11 ]
+  availability: [ 11 ]
   skills:
     experience: 10-15 years
     years: 15


### PR DESCRIPTION
## Description
Ad-hoc applications should now be available until after 13th of each month

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [x] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue
## Screenshots
Apply button back up:
<img width="1063" alt="Screenshot 2024-09-11 at 6 24 26 PM" src="https://github.com/user-attachments/assets/297cd00d-78c6-4f3a-be23-b229f672be88">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->