### PR TITLE
Fix: handle mentors availability for months outside mentorship cycle

### DIFF
--- a/assets/js/registration.js
+++ b/assets/js/registration.js
@@ -1,5 +1,7 @@
 const registrationController = (function(jQuery) {
     const CLASS_HIDDEN = 'd-none';
+    const MENTORSHIP_OPEN_MONTH = 3; //March
+    const MENTORSHIP_CLOSE_MONTH = 11; //November
 
     const checkAdHocSessions = function() {
         jQuery('.card-mentor').each(function() {
@@ -14,8 +16,13 @@ const registrationController = (function(jQuery) {
                 const currentDate = new Date();
                 const currentDay = currentDate.getDate();
                 const currentMonth = currentDate.getMonth() + 1;
+
+                const isMentorshipCycle = (
+                    currentMonth >= MENTORSHIP_OPEN_MONTH && 
+                    currentMonth <= MENTORSHIP_CLOSE_MONTH
+                );
                 
-                if (currentDay <= daysOpen) {
+                if (currentDay <= daysOpen && isMentorshipCycle) {
                     if (mentorType !== 'long-term') {
                         if (mentorAvailability.includes(currentMonth.toString())) {
                             jQuery(`#registration-link-${mentorIndex}`).removeClass(CLASS_HIDDEN);


### PR DESCRIPTION
## Description
A fix for the UI issue where all mentors are showing 'Not Available' on their mentor profiles. 
This is because the registration period is open (first 15 days of each month) but mentorship cycle has ended for the year (i.e no mentor has adhoc availability for Dec)
The PR adds logic to handle months outside the mentorship cycle (March - November)


## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue

## Screenshots
**Before**:
<img width="1321" alt="Screenshot 2024-12-04 at 6 28 07 PM" src="https://github.com/user-attachments/assets/34959585-2a14-468e-b469-8cde87d15212">

**After:**
<img width="1321" alt="Screenshot 2024-12-04 at 6 27 51 PM" src="https://github.com/user-attachments/assets/662cc709-ca84-420e-96c1-741c206dff12">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->