### PR TITLE
docs(README): fix Code of Conduct redirect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 The Women Coding Community is a community dedicated to inspiring women to excel in their technology careers. Our events cover various topics around software engineering.
 If you're interested in joining the community as a member or volunteer please visit our [website](https://womencodingcommunity.com/) or join [our Slack](https://join.slack.com/t/womencodingcommunity/shared_invite/zt-2hpjwpx7l-rgceYBIWp6pCiwc0hVsX8A).
 
-Check out [Code of Conduct]([https://WomenCodingCommunity.github.io/code-of-conduct/](https://womencodingcommunity.com/code-of-conduct))
+Check out [Code of Conduct]([https://WomenCodingCommunity.github.io/code-of-conduct/](https://womencodingcommunity.com/code-of-conduct)
 
 # About
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 The Women Coding Community is a community dedicated to inspiring women to excel in their technology careers. Our events cover various topics around software engineering.
 If you're interested in joining the community as a member or volunteer please visit our [website](https://womencodingcommunity.com/) or join [our Slack](https://join.slack.com/t/womencodingcommunity/shared_invite/zt-2hpjwpx7l-rgceYBIWp6pCiwc0hVsX8A).
 
-Check out [Code of Conduct](https://WomenCodingCommunity.github.io/code-of-conduct/)
+Check out [Code of Conduct]([https://WomenCodingCommunity.github.io/code-of-conduct/](https://womencodingcommunity.com/code-of-conduct))
 
 # About
 


### PR DESCRIPTION
The Code of Conduct Link goes to a website 404. I changed it so its the code of coinduct url from the Offical Page

## Description
<!--- Describe your changes in detail --> 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [x] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots
<!--  If you are changing html, css or new resources it is mandatory to add screenshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [ ] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->