### PR TITLE
Fix Atomic Habits link (was example.com)

### DIFF
--- a/_posts/2025-07-02-habits-challenge-lessons.html
+++ b/_posts/2025-07-02-habits-challenge-lessons.html
@@ -17,7 +17,7 @@ category: Productivity
 
     <p>As a pragmatist, I generally avoided New Year’s resolutions. I certainly avoided publicising them. The fear of disappointment felt too great.</p>
 
-    <p>But after our recent book club on <a href="https://example.com" target="_blank"><em>Atomic Habits</em> by James Clear</a>, I decided to run a four-week habit challenge with the Women Coding Community. The concept was simple: each participant wrote down their name and the habits they wanted to form in a shared spreadsheet. Progress would be tracked daily and weekly.</p>
+    <p>But after our recent book club on <a href="https://jamesclear.com/atomic-habits" target="_blank"><em>Atomic Habits</em> by James Clear</a>, I decided to run a four-week habit challenge with the Women Coding Community. The concept was simple: each participant wrote down their name and the habits they wanted to form in a shared spreadsheet. Progress would be tracked daily and weekly.</p>
 
     <p>The timing was perfect. I had recently joined an LLM Engineering course in the community but had struggled to get started. So my first habit was: <strong>15 minutes of LLM Engineering study per day</strong>. Following Clear’s advice, I made it as easy as possible — not quite the 2-minute version he recommends, but 15 felt like the sweet spot: long enough to get immersed, short enough to feel easy.</p>
 


### PR DESCRIPTION
## Description
In the blog "Breaking the Procrastination Cycle", there was a link to Atomic Habits. I had set it to 'example.com' and forgot to change. This PR fixes the link (linking to the author's website instead of example.com).

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue
Issue 522 for the blog.


## Screenshots
Screenshot of the link. The text has not changed.
<img width="723" height="158" alt="atomic_habits_link_screenshot" src="https://github.com/user-attachments/assets/62d80bf0-01bf-4846-9365-bf7829790666" />


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x ] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 