### PR TITLE
Fix: Ensure events to import is sorted in order

### DIFF
--- a/tools/meetup_import.py
+++ b/tools/meetup_import.py
@@ -179,9 +179,12 @@ def get_upcoming_meetups_from_ical_file(ical_path: str) -> list[MeetupEvents]:
     with open(ical_path, "r", encoding="utf-8") as f:
         calendar = Calendar(f.read())
 
+    # sort events to ensure order by event date
+    sorted_events = sorted(calendar.events, key=lambda e: e.begin)
+
     upcoming_meetups: list[MeetupEvents] = []
 
-    for event in calendar.events:
+    for event in sorted_events:
         title = event.name
         date_obj = event.begin.datetime
         expiration = date_obj.strftime("%Y%m%d")
@@ -279,7 +282,7 @@ def fetch_events():
     ical_file_path = "files/meetup.ics"
     yml_file_path = "../_data/imported_events.yml"
 
-    logging.info("Params: iCal URL: %s yml: %s mode: %s", ical_file_path, yml_file_path)
+    logging.info("Params: iCal URL: %s yml: %s", ical_file_path, yml_file_path)
     upcoming_meetups = get_upcoming_meetups_from_ical_file(ical_file_path)
     
     logging.info("Upcoming Meetups:")


### PR DESCRIPTION
## Description

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue

## Screenshots
Tested locally that events sort correctly
<img width="1240" height="601" alt="Screenshot 2025-09-21 at 10 09 59 AM" src="https://github.com/user-attachments/assets/c20a30b8-d3c6-4e91-88f6-6ab74eaccfb5" />
<img width="1240" height="756" alt="Screenshot 2025-09-21 at 10 10 10 AM" src="https://github.com/user-attachments/assets/a026a1d5-4ec7-458e-ad05-8da4d27ec4bf" />


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->