### PR TITLE
Add YouTube resources for Mar 12 and Mar 13 Java Bootcamp events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -2103,9 +2103,7 @@
     resources:
       presentation:
         - https://docs.google.com/presentation/d/1qIiJUr6Lr9io3n3EbFFPiGMpOYdIrM6H/edit?slide=id.p1#slide=id.p1
-        - https://docs.google.com/presentation/d/1GzJ5OlceIw-fZt6ptiQQY1OgiXxJWv_LKSTZKgBE3uQ/edit?slide=id.p1#slide=id.p1
       youtube: https://youtu.be/K6Vr4oMHuEI
-
 
 - title: |
     Java Bootcamp: The Grand Finale Hack Hour
@@ -2127,6 +2125,8 @@
     title: View meetup event
     target: _target
     resources:
+      presentation:
+        - https://docs.google.com/presentation/d/1GzJ5OlceIw-fZt6ptiQQY1OgiXxJWv_LKSTZKgBE3uQ/edit?slide=id.p1#slide=id.p1
       youtube: https://www.youtube.com/watch?v=x7Fz8BvZb_Q
 
 - title: |

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -2102,6 +2102,7 @@
     target: _target
     resources:
       youtube: https://youtu.be/K6Vr4oMHuEI
+      presentation: https://docs.google.com/presentation/d/1qIiJUr6Lr9io3n3EbFFPiGMpOYdIrM6H/edit?usp=sharing&ouid=106396054396839804673&rtpof=true&sd=true
 
 - title: |
     Java Bootcamp: The Grand Finale Hack Hour

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -2101,8 +2101,11 @@
     title: View meetup event
     target: _target
     resources:
+      presentation:
+        - https://docs.google.com/presentation/d/1qIiJUr6Lr9io3n3EbFFPiGMpOYdIrM6H/edit?slide=id.p1#slide=id.p1
+        - https://docs.google.com/presentation/d/1GzJ5OlceIw-fZt6ptiQQY1OgiXxJWv_LKSTZKgBE3uQ/edit?slide=id.p1#slide=id.p1
       youtube: https://youtu.be/K6Vr4oMHuEI
-      presentation: https://docs.google.com/presentation/d/1qIiJUr6Lr9io3n3EbFFPiGMpOYdIrM6H/edit?usp=sharing&ouid=106396054396839804673&rtpof=true&sd=true
+
 
 - title: |
     Java Bootcamp: The Grand Finale Hack Hour

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -2100,6 +2100,8 @@
     path: https://www.meetup.com/women-coding-community/events/313257077/
     title: View meetup event
     target: _target
+    resources:
+      youtube: https://youtu.be/K6Vr4oMHuEI
 
 - title: |
     Java Bootcamp: The Grand Finale Hack Hour
@@ -2120,6 +2122,8 @@
     path: https://www.meetup.com/women-coding-community/events/313574241/
     title: View meetup event
     target: _target
+    resources:
+      youtube: https://www.youtube.com/watch?v=x7Fz8BvZb_Q
 
 - title: |
     Own your voice: Assertive Communication for Women in Tech


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> Related to closed issue #691 
Added YouTube recording links to the Mar 12 and Mar 13 Java Bootcamp events:

Java Bootcamp: Vibe Coding with AI Agents & MCP (Thu Mar 12)
Java Bootcamp: The Grand Finale Hack Hour (Fri Mar 13)

<!--- Why is this change required? What problem does it solve? --> Added YouTube recording links to the Mar 12 and Mar 13 Java Bootcamp events in events.yml. These recordings were missing from the existing event entries.

<!--- If it fixes an open issue, please link to the issue here. -->

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [x] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Related to closed issue #691 


## Screenshots
<!--  If you are changing html, css or new resources it is mandatory to add screenshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->